### PR TITLE
add progress bar to learning module

### DIFF
--- a/src/components/learningModule/LearningModule.js
+++ b/src/components/learningModule/LearningModule.js
@@ -4,6 +4,7 @@ import Button from '../button/Button';
 import Intro from '../intro/Intro';
 
 import './Styles.scss';
+import ProgressBar from '../progressBar/ProgressBar';
 
 const LearningModule = ({setGameStatus, gameStatus}) => {
   const [currentQuestionId, setCurrentQuestionId] = React.useState(0);
@@ -53,6 +54,11 @@ const LearningModule = ({setGameStatus, gameStatus}) => {
 
   return (
     <div className="learningModule">
+      <ProgressBar
+        segments={quizData.totalQuestions + 1}
+        currentQuestionId={currentQuestionId}
+        isComplete={isComplete}
+      />
       { currentQuestion.title && !isComplete &&
         <>
           <div className="learningModule__header">

--- a/src/components/progressBar/ProgressBar.js
+++ b/src/components/progressBar/ProgressBar.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import './Styles.scss'
+
+const ProgressBar = ({segments, currentQuestionId, isComplete}) => {
+
+  const width =  `${((currentQuestionId + 1) / segments) * 100}%`
+  return (
+    <div className="progressBar">
+      <div className="progressBar__line">
+        <div className="progressBar__completedBar" style={isComplete ? {width:"100%", borderRadius:"50px"} : {width:width}}>
+
+        </div>
+
+      </div>
+      
+    </div>
+  )
+}
+
+export default ProgressBar

--- a/src/components/progressBar/ProgressBar.js
+++ b/src/components/progressBar/ProgressBar.js
@@ -5,15 +5,13 @@ import './Styles.scss'
 const ProgressBar = ({segments, currentQuestionId, isComplete}) => {
 
   const width =  `${((currentQuestionId + 1) / segments) * 100}%`
+  
   return (
     <div className="progressBar">
       <div className="progressBar__line">
         <div className="progressBar__completedBar" style={isComplete ? {width:"100%", borderRadius:"50px"} : {width:width}}>
-
         </div>
-
-      </div>
-      
+      </div> 
     </div>
   )
 }

--- a/src/components/progressBar/Styles.scss
+++ b/src/components/progressBar/Styles.scss
@@ -22,9 +22,9 @@
     position: absolute;
     top: -5px;
     background-color: $barney;
-    border-radius: 50px 0 0 50px;
+    border-radius: 7.5px 0 0 7.4px;
     height: 15px;
-    transition: .7s;
+    transition: width .7s;
     @media only screen and (max-width: $tablet) {
       max-width: 90%;
     }

--- a/src/components/progressBar/Styles.scss
+++ b/src/components/progressBar/Styles.scss
@@ -22,7 +22,7 @@
     position: absolute;
     top: -5px;
     background-color: $barney;
-    border-radius: 7.5px 0 0 7.4px;
+    border-radius: 7.5px 0 0 7.5px;
     height: 15px;
     transition: width .7s;
     @media only screen and (max-width: $tablet) {

--- a/src/components/progressBar/Styles.scss
+++ b/src/components/progressBar/Styles.scss
@@ -1,0 +1,32 @@
+@import '../../styles/utils/colors';
+@import '../../styles/utils/breakpoints';
+
+
+.progressBar {
+  position: relative;
+  width: 100%;
+  @media only screen and (max-width: $tablet) {
+    display:flex;
+    justify-content:center;
+  }
+
+  &__line {
+    background-color: $elephant-paw;
+    height: 5px;
+    margin: 10 auto;
+    @media only screen and (max-width: $tablet) {
+      width: 90%;
+    }
+  }
+  &__completedBar {
+    position: absolute;
+    top: -5px;
+    background-color: $barney;
+    border-radius: 50px 0 0 50px;
+    height: 15px;
+    transition: .7s;
+    @media only screen and (max-width: $tablet) {
+      max-width: 90%;
+    }
+  }
+}


### PR DESCRIPTION
Create a progress bar to show the user how far they have progressed through a question set. 

The progress bar has N+1 segments where N is the number of questions in a series. 
When the user finishes all the questions, the screen announces the questions are complete and the progress bar is fully covered.

The progress bar is animated each time the user advances to the next question.